### PR TITLE
Use versions other than dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "php": ">=5.6",
     "nette/application": "^2.4",
     "nette/http": "^2.4",
-    "apitte/core": "dev-master",
-    "contributte/psr7-http-message": "dev-master"
+    "apitte/core": "^0.2.0",
+    "contributte/psr7-http-message": "^0.3.0"
   },
   "require-dev": {
     "ninjify/qa": "~0.4.0",


### PR DESCRIPTION
Currently, this package cannot be installed because there are conflicts.

This PR makes use of tagged versions or apitte/core and contributte/contributte/psr7-http-message.